### PR TITLE
QUAY-BUILDER-QEMU support on IBMZ

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -14,10 +14,10 @@ jobs:
   build-and-publish:
     name: Publish container image
     env:
-      BRANCH_PREFIX: IBMZ_Support # IMPORTANT! this must match the .on.push.branches prefix!
+      BRANCH_PREFIX: redhat- # IMPORTANT! this must match the .on.push.branches prefix!
       REGISTRY: quay.io/projectquay
       REPO_NAME: ${{ github.event.repository.name }}
-      TAG_SUFFIX: unstable
+      TAG_SUFFIX: -unstable
     runs-on: 'ubuntu-latest'
     steps:
       - name: Check out the repo
@@ -29,12 +29,12 @@ jobs:
         run: |
           BRANCH_NAME=${GITHUB_REF#refs/heads/}
           echo "::set-output name=version::${BRANCH_NAME/${{ env.BRANCH_PREFIX }}/}"
-#       - name: Login to Quay.io
-#         uses: docker/login-action@v1
-#         with:
-#           registry: quay.io
-#           username: ${{ secrets.QUAY_USER }}
-#           password: ${{ secrets.QUAY_TOKEN }}
+      - name: Login to Quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -50,7 +50,7 @@ jobs:
         with:
           platforms: linux/amd64, linux/s390x
           build-args: channel=stable
-          push: false
+          push: true
           file: Dockerfile
           tags: ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:${{ github.event.inputs.tag || env.TAG }}
 

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -42,7 +42,7 @@ jobs:
         env:
           TAG: ${{ steps.version-from-branch.outputs.version }}${{ env.TAG_SUFFIX }}
         with:
-          build-args: channel=stable version=current
+          build-args: channel=stable
           push: true
           file: Dockerfile
           tags: ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:${{ github.event.inputs.tag || env.TAG }}

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -14,10 +14,10 @@ jobs:
   build-and-publish:
     name: Publish container image
     env:
-      BRANCH_PREFIX: redhat- # IMPORTANT! this must match the .on.push.branches prefix!
+      BRANCH_PREFIX: IBMZ_Support # IMPORTANT! this must match the .on.push.branches prefix!
       REGISTRY: quay.io/projectquay
       REPO_NAME: ${{ github.event.repository.name }}
-      TAG_SUFFIX: -unstable
+      TAG_SUFFIX: unstable
     runs-on: 'ubuntu-latest'
     steps:
       - name: Check out the repo
@@ -29,20 +29,31 @@ jobs:
         run: |
           BRANCH_NAME=${GITHUB_REF#refs/heads/}
           echo "::set-output name=version::${BRANCH_NAME/${{ env.BRANCH_PREFIX }}/}"
-      - name: Login to Quay.io
-        uses: docker/login-action@v1
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USER }}
-          password: ${{ secrets.QUAY_TOKEN }}
+#       - name: Login to Quay.io
+#         uses: docker/login-action@v1
+#         with:
+#           registry: quay.io
+#           username: ${{ secrets.QUAY_USER }}
+#           password: ${{ secrets.QUAY_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
         env:
           TAG: ${{ steps.version-from-branch.outputs.version }}${{ env.TAG_SUFFIX }}
         with:
+          platforms: linux/amd64, linux/s390x
           build-args: channel=stable
-          push: true
+          push: false
           file: Dockerfile
           tags: ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:${{ github.event.inputs.tag || env.TAG }}
+
+
+
+

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -53,7 +53,3 @@ jobs:
           push: true
           file: Dockerfile
           tags: ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:${{ github.event.inputs.tag || env.TAG }}
-
-
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ ARG location
 RUN [ -z "${channel}" ] && echo "ARG channel is required" && exit 1 || true
 
 RUN yum -y install jq xz
-
 RUN ARCH=$(uname -m) ; echo $ARCH \
     ; if [ "$ARCH" == "s390x" ] ; then ARCH=s390x ; elif [ "$ARCH" == "x86_64" ] ; then ARCH=x86_64 ; fi \
     ; curl https://builds.coreos.fedoraproject.org/streams/${channel}.json -o stable.json && \
@@ -23,8 +22,9 @@ RUN if [[ -z "$arg" ]] ; then \
         unxz coreos_production_qemu_image.qcow2.xz ; \
     else \
 	echo "Downloading" ${location} && \
-        curl -s -o coreos_production_qemu_image.qcow2.xz ${location} && unxz coreos_production_qemu_image.qcow2.xz \
-    ; fi
+        curl -s -o coreos_production_qemu_image.qcow2.xz ${location} && \
+	unxz coreos_production_qemu_image.qcow2.xz ; \
+    fi
 
 FROM base AS final
 ARG channel=stable
@@ -33,9 +33,9 @@ RUN mkdir -p /userdata
 WORKDIR /userdata
 
 RUN yum -y update && \
-    yum -y remove jq && \
-    yum -y install openssh-clients qemu-kvm && \
-    yum -y clean all
+    	yum -y remove jq && \
+    	yum -y install openssh-clients qemu-kvm && \
+    	yum -y clean all
 
 COPY --from=executor-img /coreos_production_qemu_image.qcow2 /userdata/coreos_production_qemu_image.qcow2
 COPY start.sh /userdata/start.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,23 +4,24 @@ ARG location
 
 RUN [ -z "${channel}" ] && echo "ARG channel is required" && exit 1 || true
 
-RUN yum -y install jq xz
+RUN yum -y install jq
 RUN ARCH=$(uname -m) ; echo $ARCH \
-    ; curl https://builds.coreos.fedoraproject.org/streams/${channel}.json -o stable.json && \
-        cat stable.json | jq --arg arch "$ARCH" '.architectures[$arch].artifacts.qemu.release' | jq -r
+	; curl https://builds.coreos.fedoraproject.org/streams/${channel}.json -o stable.json && \
+		cat stable.json | jq --arg arch "$ARCH" '.architectures[$arch].artifacts.qemu.release' | jq -r
+
 
 FROM base AS executor-img
 
 RUN if [[ -z "$arg" ]] ; then \
 	ARCH=$(uname -m) ; echo $ARCH ; \
 	echo "Downloading" $(cat stable.json | jq --arg arch "$ARCH" '.architectures[$arch].artifacts.qemu.formats."qcow2.xz".disk.location' | jq -r ) && \
-        curl -s -o coreos_production_qemu_image.qcow2.xz $(cat stable.json | jq --arg arch "$ARCH" '.architectures[$arch].artifacts.qemu.formats."qcow2.xz".disk.location' | jq -r ) && \
-        unxz coreos_production_qemu_image.qcow2.xz ; \
-    else \
+	curl -s -o coreos_production_qemu_image.qcow2.xz $(cat stable.json | jq --arg arch "$ARCH" '.architectures[$arch].artifacts.qemu.formats."qcow2.xz".disk.location' | jq -r ) && \
+		unxz coreos_production_qemu_image.qcow2.xz ; \
+	else \
 	echo "Downloading" ${location} && \
-        curl -s -o coreos_production_qemu_image.qcow2.xz ${location} && \
-	unxz coreos_production_qemu_image.qcow2.xz ; \
-    fi
+	curl -s -o coreos_production_qemu_image.qcow2.xz ${location} && unxz coreos_production_qemu_image.qcow2.xz \
+	; fi
+
 
 FROM base AS final
 ARG channel=stable
@@ -29,9 +30,9 @@ RUN mkdir -p /userdata
 WORKDIR /userdata
 
 RUN yum -y update && \
-    	yum -y remove jq && \
-    	yum -y install openssh-clients qemu-kvm && \
-    	yum -y clean all
+	yum -y remove jq && \
+	yum -y install openssh-clients qemu-kvm && \
+	yum -y clean all
 
 COPY --from=executor-img /coreos_production_qemu_image.qcow2 /userdata/coreos_production_qemu_image.qcow2
 COPY start.sh /userdata/start.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ FROM base AS executor-img
 
 RUN if [[ -z "$arg" ]] ; then \
 	ARCH=$(uname -m) ; echo $ARCH ; \
-	echo "Downloading" $(cat stable.json | jq --arg arch "$ARCH" '.architectures[$arch].artifacts.qemu.formats."qcow2.xz".disk.location' | jq -r ) && \
+	echo "Downloading" $(cat stable.json | jq -r --arg arch "$ARCH" '.architectures[$arch].artifacts.qemu.formats."qcow2.xz".disk.location') && \
 	curl -s -o coreos_production_qemu_image.qcow2.xz $(cat stable.json | jq --arg arch "$ARCH" '.architectures[$arch].artifacts.qemu.formats."qcow2.xz".disk.location' | jq -r ) && \
 		unxz coreos_production_qemu_image.qcow2.xz ; \
 	else \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,8 @@ RUN if [[ -z "$arg" ]] ; then \
         unxz coreos_production_qemu_image.qcow2.xz ; \
     else \
 	echo "Downloading" ${location} && \
-        curl -s -o coreos_production_qemu_image.qcow2.xz ${location} && \
-        unxz coreos_production_qemu_image.qcow2.xz ; \
-    fi
+        curl -s -o coreos_production_qemu_image.qcow2.xz ${location} && unxz coreos_production_qemu_image.qcow2.xz \
+    ; fi
 
 FROM base AS final
 ARG channel=stable
@@ -34,9 +33,9 @@ RUN mkdir -p /userdata
 WORKDIR /userdata
 
 RUN yum -y update && \
-        yum -y remove jq && \
-        yum -y install openssh-clients qemu-kvm && \
-        yum -y clean all
+    yum -y remove jq && \
+    yum -y install openssh-clients qemu-kvm && \
+    yum -y clean all
 
 COPY --from=executor-img /coreos_production_qemu_image.qcow2 /userdata/coreos_production_qemu_image.qcow2
 COPY start.sh /userdata/start.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN [ -z "${channel}" ] && echo "ARG channel is required" && exit 1 || true
 RUN yum -y install jq
 RUN ARCH=$(uname -m) ; echo $ARCH \
 	; curl https://builds.coreos.fedoraproject.org/streams/${channel}.json -o stable.json && \
-		cat stable.json | jq --arg arch "$ARCH" '.architectures[$arch].artifacts.qemu.release' | jq -r
+		cat stable.json | jq -r --arg arch "$ARCH" '.architectures[$arch].artifacts.qemu.release'
 
 
 FROM base AS executor-img
@@ -15,7 +15,7 @@ FROM base AS executor-img
 RUN if [[ -z "$arg" ]] ; then \
 	ARCH=$(uname -m) ; echo $ARCH ; \
 	echo "Downloading" $(cat stable.json | jq -r --arg arch "$ARCH" '.architectures[$arch].artifacts.qemu.formats."qcow2.xz".disk.location') && \
-	curl -s -o coreos_production_qemu_image.qcow2.xz $(cat stable.json | jq --arg arch "$ARCH" '.architectures[$arch].artifacts.qemu.formats."qcow2.xz".disk.location' | jq -r ) && \
+	curl -s -o coreos_production_qemu_image.qcow2.xz $(cat stable.json | jq -r --arg arch "$ARCH" '.architectures[$arch].artifacts.qemu.formats."qcow2.xz".disk.location') && \
 		unxz coreos_production_qemu_image.qcow2.xz ; \
 	else \
 	echo "Downloading" ${location} && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,31 @@
-FROM centos:8 as base
+FROM quay.io/centos/centos:stream9 as base
 ARG channel="stable"
 ARG location
 
 RUN [ -z "${channel}" ] && echo "ARG channel is required" && exit 1 || true
 
-RUN yum -y install jq
-RUN curl https://builds.coreos.fedoraproject.org/streams/${channel}.json -o stable.json && \
-	cat stable.json | jq '.architectures.x86_64.artifacts.qemu.release' | tr -d '"'
+RUN yum -y install jq xz
+
+RUN ARCH=$(uname -m) ; echo $ARCH \
+    ; if [ "$ARCH" == "s390x" ] ; then ARCH=s390x ; elif [ "$ARCH" == "x86_64" ] ; then ARCH=x86_64 ; fi \
+    ; curl https://builds.coreos.fedoraproject.org/streams/${channel}.json -o stable.json && \
+        cat stable.json | jq --arg arch "$ARCH" '.architectures[$arch].artifacts.qemu.release' | tr -d '"' 
+
 
 
 FROM base AS executor-img
 
 RUN if [[ -z "$arg" ]] ; then \
-	echo "Downloading" $(cat stable.json | jq '.architectures.x86_64.artifacts.qemu.formats."qcow2.xz".disk.location' | tr -d '"') && \
-	curl -s -o coreos_production_qemu_image.qcow2.xz $(cat stable.json | jq '.architectures.x86_64.artifacts.qemu.formats."qcow2.xz".disk.location' | tr -d '"') && unxz coreos_production_qemu_image.qcow2.xz ; \
-	else \
+	ARCH=$(uname -m) ; echo $ARCH ; \
+	if [ "$ARCH" == "s390x" ] ; then ARCH=s390x ; elif [ "$ARCH" == "x86_64" ] ; then ARCH=x86_64 ; fi ; \
+	echo "Downloading" $(cat stable.json | jq --arg arch "$ARCH" '.architectures[$arch].artifacts.qemu.formats."qcow2.xz".disk.location' | tr -d '"') && \
+        curl -s -o coreos_production_qemu_image.qcow2.xz $(cat stable.json | jq --arg arch "$ARCH" '.architectures[$arch].artifacts.qemu.formats."qcow2.xz".disk.location' | tr -d '"') && \
+        unxz coreos_production_qemu_image.qcow2.xz ; \
+    else \
 	echo "Downloading" ${location} && \
-	curl -s -o coreos_production_qemu_image.qcow2.xz ${location} && unxz coreos_production_qemu_image.qcow2.xz \
-	; fi
-
+        curl -s -o coreos_production_qemu_image.qcow2.xz ${location} && \
+        unxz coreos_production_qemu_image.qcow2.xz ; \
+    fi
 
 FROM base AS final
 ARG channel=stable
@@ -27,9 +34,9 @@ RUN mkdir -p /userdata
 WORKDIR /userdata
 
 RUN yum -y update && \
-	yum -y remove jq && \
-	yum -y install openssh-clients qemu-kvm && \
-	yum -y clean all
+        yum -y remove jq && \
+        yum -y install openssh-clients qemu-kvm && \
+        yum -y clean all
 
 COPY --from=executor-img /coreos_production_qemu_image.qcow2 /userdata/coreos_production_qemu_image.qcow2
 COPY start.sh /userdata/start.sh

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ ARCH=$(uname -m)
 if [ -z "$CLOUD_IMAGE" ]; then
     CHANNEL=${CHANNEL:-"stable"}
     CHANNEL_MANIFEST_JSON=`curl https://builds.coreos.fedoraproject.org/streams/${CHANNEL}.json`
-    LOCATION=`echo $CHANNEL_MANIFEST_JSON | jq --arg arch "$ARCH" '.architectures[$arch].artifacts.qemu.formats."qcow2.xz".disk.location' | jq -r`
+    LOCATION=`echo $CHANNEL_MANIFEST_JSON | jq -r --arg arch "$ARCH" '.architectures[$arch].artifacts.qemu.formats."qcow2.xz".disk.location'`
 
     time docker build --build-arg=channel=$CHANNEL --build-arg --build-arg -t $IMAGE:$TAG .
 else

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,6 @@ if [ -z "$CLOUD_IMAGE" ]; then
     CHANNEL=${CHANNEL:-"stable"}
     CHANNEL_MANIFEST_JSON=`curl https://builds.coreos.fedoraproject.org/streams/${CHANNEL}.json`
     LOCATION=`echo $CHANNEL_MANIFEST_JSON | jq --arg arch "$ARCH" '.architectures[$arch].artifacts.qemu.formats."qcow2.xz".disk.location' | tr -d '"'`
-    VERSION=`echo $CHANNEL_MANIFEST_JSON | jq --arg arch "$ARCH" '.architectures[$arch].artifacts.qemu.release' | tr -d '"'`
 
     time docker build --build-arg=channel=$CHANNEL --build-arg --build-arg -t $IMAGE:$TAG .
 else

--- a/build.sh
+++ b/build.sh
@@ -4,12 +4,13 @@ set -o nounset
 TAG=${TAG:-"stable"}
 IMAGE=${IMAGE:-"quay.io/quay/quay-builder-qemu-fedoracoreos"}
 CLOUD_IMAGE=${CLOUD_IMAGE:-""}
+ARCH=$(uname -m)
 
 if [ -z "$CLOUD_IMAGE" ]; then
     CHANNEL=${CHANNEL:-"stable"}
     CHANNEL_MANIFEST_JSON=`curl https://builds.coreos.fedoraproject.org/streams/${CHANNEL}.json`
-    LOCATION=`echo $CHANNEL_MANIFEST_JSON | jq '.architectures.x86_64.artifacts.qemu.formats."qcow2.xz".disk.location' | tr -d '"'`
-    VERSION=`echo $CHANNEL_MANIFEST_JSON | jq '.architectures.x86_64.artifacts.qemu.release' | tr -d '"'`
+    LOCATION=`echo $CHANNEL_MANIFEST_JSON | jq --arg arch "$ARCH" '.architectures[$arch].artifacts.qemu.formats."qcow2.xz".disk.location' | tr -d '"'`
+    VERSION=`echo $CHANNEL_MANIFEST_JSON | jq --arg arch "$ARCH" '.architectures[$arch].artifacts.qemu.release' | tr -d '"'`
 
     time docker build --build-arg=channel=$CHANNEL --build-arg --build-arg -t $IMAGE:$TAG .
 else

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ ARCH=$(uname -m)
 if [ -z "$CLOUD_IMAGE" ]; then
     CHANNEL=${CHANNEL:-"stable"}
     CHANNEL_MANIFEST_JSON=`curl https://builds.coreos.fedoraproject.org/streams/${CHANNEL}.json`
-    LOCATION=`echo $CHANNEL_MANIFEST_JSON | jq --arg arch "$ARCH" '.architectures[$arch].artifacts.qemu.formats."qcow2.xz".disk.location' | tr -d '"'`
+    LOCATION=`echo $CHANNEL_MANIFEST_JSON | jq --arg arch "$ARCH" '.architectures[$arch].artifacts.qemu.formats."qcow2.xz".disk.location' | jq -r`
 
     time docker build --build-arg=channel=$CHANNEL --build-arg --build-arg -t $IMAGE:$TAG .
 else


### PR DESCRIPTION
# Description

Added Support for s390x architecture 

## Changes that have been made

> Since centos:8 went to [EOL](https://www.centos.org/centos-linux-eol/) and doesn't support s390x

-  Changed base image from **centos:8** to **quay.io/centos/centos:stream9** which supports amd64, s390x, ppc64le, and arm64 

> Since the build needs to be done on different platforms in GitHub Workflow actions

-  Added, **setup-qemu-action** and **setup-buildx-action** ,GitHub actions in _build-and-publish.yaml_ workflow file

-  Updated _Dockerfile_ and _build.sh_ such that it will publish the build image based on the architecture

-  VERSION variable is removed from the _build.sh_ and _build-and-publish.yaml_ as it is not using in the repo

## Tests that have been done so far

- [x] Manually tested to build the image using the _Dockerfile_ in both **s390x** and **amd64**.
- [x] Manually brought up the **QEMU** inside the docker container following the _start.sh_ file in both **s390x** and **amd64**.
- [x] Successfully ran the GitHub Actions Workflow file with _workflow_dispatch_ event trigger.