### PR TITLE
ppc64le support for quay-builder-qemu

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -42,14 +42,57 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       
-      - name: Build and push
+      - name: Build container for amd64
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
+        env:
+          TAG: amd64
+        with:
+          platforms: linux/amd64
+          build-args: |
+            channel=stable
+            image=quay.io/centos/centos:stream9
+          push: true
+          file: Dockerfile
+          tags: ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:${{ github.event.inputs.tag }}-${{ env.TAG }}
+          provenance: false
+
+      - name: Build and push s390x
+        id: docker_build_s390x
+        uses: docker/build-push-action@v3
+        env:
+          TAG: s390x
+        with:
+          platforms: linux/s390x
+          build-args: |
+            channel=stable
+            image=quay.io/centos/centos:stream9
+          push: true
+          file: Dockerfile
+          tags: ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:${{ github.event.inputs.tag }}-${{ env.TAG }}
+          provenance: false
+
+      - name: Build and push ppc64le
+        id: docker_build_ppc64le
+        uses: docker/build-push-action@v3
+        env:
+          TAG: ppc64le
+        with:
+          platforms: linux/ppc64le
+          build-args: |
+            channel=stable
+            image=quay.io/centos/centos:stream8 
+          push: true
+          file: Dockerfile
+          tags: ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:${{ github.event.inputs.tag }}-${{ env.TAG }}
+          provenance: false
+
+      - name: Build and push multi-arch manifest
+        uses: Noelware/docker-manifest-action@master
         env:
           TAG: ${{ steps.version-from-branch.outputs.version }}${{ env.TAG_SUFFIX }}
         with:
-          platforms: linux/amd64, linux/s390x
-          build-args: channel=stable
+          inputs: ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:${{ github.event.inputs.tag || env.TAG }}
+          images: ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:${{ github.event.inputs.tag }}-amd64,${{ env.REGISTRY }}/${{ env.REPO_NAME }}:${{ github.event.inputs.tag }}-s390x,${{ env.REGISTRY }}/${{ env.REPO_NAME }}:${{ github.event.inputs.tag }}-ppc64le
           push: true
-          file: Dockerfile
-          tags: ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:${{ github.event.inputs.tag || env.TAG }}
+          amend: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM quay.io/centos/centos:stream9 as base
+ARG image="quay.io/centos/centos:stream9"
+FROM ${image} as base
 ARG channel="stable"
 ARG location
 
@@ -6,22 +7,23 @@ RUN [ -z "${channel}" ] && echo "ARG channel is required" && exit 1 || true
 
 RUN yum -y install jq xz
 RUN ARCH=$(uname -m) ; echo $ARCH \
-	; curl https://builds.coreos.fedoraproject.org/streams/${channel}.json -o stable.json && \
-		cat stable.json | jq -r --arg arch "$ARCH" '.architectures[$arch].artifacts.qemu.release'
+        ; curl https://builds.coreos.fedoraproject.org/streams/${channel}.json -o stable.json && \
+                cat stable.json | jq -r --arg arch "$ARCH" '.architectures[$arch].artifacts.qemu.release'
 
 
 FROM base AS executor-img
 
-RUN if [[ -z "$arg" ]] ; then \
-	ARCH=$(uname -m) ; echo $ARCH ; \
-	echo "Downloading" $(cat stable.json | jq -r --arg arch "$ARCH" '.architectures[$arch].artifacts.qemu.formats."qcow2.xz".disk.location') && \
-	curl -s -o coreos_production_qemu_image.qcow2.xz $(cat stable.json | jq -r --arg arch "$ARCH" '.architectures[$arch].artifacts.qemu.formats."qcow2.xz".disk.location') && \
-		unxz coreos_production_qemu_image.qcow2.xz ; \
-	else \
-	echo "Downloading" ${location} && \
-	curl -s -o coreos_production_qemu_image.qcow2.xz ${location} && unxz coreos_production_qemu_image.qcow2.xz \
-	; fi
-
+RUN ARCH=$(uname -m) ; echo $ARCH ; \
+        if [[ $ARCH == "ppc64le" ]] ; then \
+        echo "Downloading https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.1/ppc64le/fedora-coreos-36.20220906.3.1-qemu.ppc64le.qcow2.xz" && \
+        curl -s -o coreos_production_qemu_image.qcow2.xz https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.1/ppc64le/fedora-coreos-36.20220906.3.1-qemu.ppc64le.qcow2.xz && \
+        unxz coreos_production_qemu_image.qcow2.xz ; \
+        else \
+        echo $ARCH && \
+        echo "Downloading" $(cat stable.json | jq -r --arg arch "$ARCH" '.architectures[$arch].artifacts.qemu.formats."qcow2.xz".disk.location') && \
+        curl -s -o coreos_production_qemu_image.qcow2.xz $(cat stable.json | jq -r --arg arch "$ARCH" '.architectures[$arch].artifacts.qemu.formats."qcow2.xz".disk.location') && \
+        unxz coreos_production_qemu_image.qcow2.xz \
+        ; fi
 
 FROM base AS final
 ARG channel=stable
@@ -30,9 +32,9 @@ RUN mkdir -p /userdata
 WORKDIR /userdata
 
 RUN yum -y update && \
-	yum -y remove jq && \
-	yum -y install openssh-clients qemu-kvm && \
-	yum -y clean all
+        yum -y remove jq && \
+        yum -y install openssh-clients qemu-kvm && \
+        yum -y clean all
 
 COPY --from=executor-img /coreos_production_qemu_image.qcow2 /userdata/coreos_production_qemu_image.qcow2
 COPY start.sh /userdata/start.sh


### PR DESCRIPTION
Dockerfile uses `quay.io/centos/centos:stream9` for amd64/s390x builds and `quay.io/centos/centos:stream8` for ppc64le builds. `qemu-kvm` isn't availble for ppc64le on centos9.

build-and-publish.yaml creates three single-arch images and then merges them using `docker manifest` to create a multi-arch image.