### PR TITLE
Add release label and fix version/url for v3-13

### DIFF
--- a/.tekton/quay-builder-qemu-v3-13-pull-request.yaml
+++ b/.tekton/quay-builder-qemu-v3-13-pull-request.yaml
@@ -269,6 +269,7 @@ spec:
         - tags="quay"
         - url="https://docs.redhat.com/en/documentation/red_hat_quay/3.13"
         - vendor=Red Hat, Inc.
+        - cpe="cpe:/a:redhat:quay:3.13::el8"
         - release=3.13
       - name: BUILDAH_FORMAT
         value: $(params.buildah-format)

--- a/.tekton/quay-builder-qemu-v3-13-pull-request.yaml
+++ b/.tekton/quay-builder-qemu-v3-13-pull-request.yaml
@@ -269,6 +269,7 @@ spec:
         - tags="quay"
         - url="https://docs.redhat.com/en/documentation/red_hat_quay/3.13"
         - vendor=Red Hat, Inc.
+        - release=3.13
       - name: BUILDAH_FORMAT
         value: $(params.buildah-format)
       runAfter:

--- a/.tekton/quay-builder-qemu-v3-13-pull-request.yaml
+++ b/.tekton/quay-builder-qemu-v3-13-pull-request.yaml
@@ -258,7 +258,7 @@ spec:
         value:
         - com.redhat.component="quay-builder-qemu-rhcos-container"
         - name="quay/quay-builder-qemu-rhcos-rhel8"
-        - version=3.13
+        - version=3.13.10
         - io.k8s.display-name="Red Hat Quay - Builder QEMU RHCOS"
         - io.k8s.description="Red Hat Quay - Builder QEMU RHCOS"
         - io.openshift.tags="quay"

--- a/.tekton/quay-builder-qemu-v3-13-push.yaml
+++ b/.tekton/quay-builder-qemu-v3-13-push.yaml
@@ -255,7 +255,7 @@ spec:
         value:
         - com.redhat.component="quay-builder-qemu-rhcos-container"
         - name="quay/quay-builder-qemu-rhcos-rhel8"
-        - version=3.13
+        - version=3.13.10
         - io.k8s.display-name="Red Hat Quay - Builder QEMU RHCOS"
         - io.k8s.description="Red Hat Quay - Builder QEMU RHCOS"
         - io.openshift.tags="quay"

--- a/.tekton/quay-builder-qemu-v3-13-push.yaml
+++ b/.tekton/quay-builder-qemu-v3-13-push.yaml
@@ -266,6 +266,7 @@ spec:
         - tags="quay"
         - url="https://docs.redhat.com/en/documentation/red_hat_quay/3.13"
         - vendor=Red Hat, Inc.
+        - cpe="cpe:/a:redhat:quay:3.13::el8"
         - release=3.13
       - name: BUILDAH_FORMAT
         value: $(params.buildah-format)

--- a/.tekton/quay-builder-qemu-v3-13-push.yaml
+++ b/.tekton/quay-builder-qemu-v3-13-push.yaml
@@ -255,7 +255,7 @@ spec:
         value:
         - com.redhat.component="quay-builder-qemu-rhcos-container"
         - name="quay/quay-builder-qemu-rhcos-rhel8"
-        - version=3.14
+        - version=3.13
         - io.k8s.display-name="Red Hat Quay - Builder QEMU RHCOS"
         - io.k8s.description="Red Hat Quay - Builder QEMU RHCOS"
         - io.openshift.tags="quay"
@@ -264,8 +264,9 @@ spec:
         - distribution-scope="restricted"
         - description="Red Hat Quay - Builder QEMU RHCOS"
         - tags="quay"
-        - url="https://docs.redhat.com/en/documentation/red_hat_quay/3.14"
+        - url="https://docs.redhat.com/en/documentation/red_hat_quay/3.13"
         - vendor=Red Hat, Inc.
+        - release=3.13
       - name: BUILDAH_FORMAT
         value: $(params.buildah-format)
       runAfter:


### PR DESCRIPTION
## Summary
  - Add release=3.13 label to both push and pull-request pipelines
  - Fix version from 3.14 to 3.13 in push pipeline
  - Fix url from 3.14 to 3.13 in push pipeline

  ## Problem
  ECP (Enterprise Contract Policy) was failing with violation:
  `The required "release" label is missing`

  ## Solution
  Added the missing `release=3.13` label to:
  - .tekton/quay-builder-qemu-v3-13-push.yaml
  - .tekton/quay-builder-qemu-v3-13-pull-request.yaml

  Also corrected version and url from 3.14 to 3.13 in push.yaml.

  ## Testing
  After this change, ECP checks should pass successfully.