### PR TITLE
Update the version of quay-builder-qemu-rhcos-rhel8 image to 3.13.11

### DIFF
--- a/.tekton/quay-builder-qemu-v3-13-pull-request.yaml
+++ b/.tekton/quay-builder-qemu-v3-13-pull-request.yaml
@@ -258,7 +258,7 @@ spec:
         value:
         - com.redhat.component="quay-builder-qemu-rhcos-container"
         - name="quay/quay-builder-qemu-rhcos-rhel8"
-        - version=3.13.10
+        - version=3.13.11
         - io.k8s.display-name="Red Hat Quay - Builder QEMU RHCOS"
         - io.k8s.description="Red Hat Quay - Builder QEMU RHCOS"
         - io.openshift.tags="quay"

--- a/.tekton/quay-builder-qemu-v3-13-push.yaml
+++ b/.tekton/quay-builder-qemu-v3-13-push.yaml
@@ -255,7 +255,7 @@ spec:
         value:
         - com.redhat.component="quay-builder-qemu-rhcos-container"
         - name="quay/quay-builder-qemu-rhcos-rhel8"
-        - version=3.13.10
+        - version=3.13.11
         - io.k8s.display-name="Red Hat Quay - Builder QEMU RHCOS"
         - io.k8s.description="Red Hat Quay - Builder QEMU RHCOS"
         - io.openshift.tags="quay"


### PR DESCRIPTION
For quay 3.13.11 release, update the version of `quay-builder-qemu-rhcos-rhel8` image to 3.13.11