### PR TITLE
Update label for 3.13.11 release

### DIFF
--- a/.tekton/quay-builder-qemu-v3-13-pull-request.yaml
+++ b/.tekton/quay-builder-qemu-v3-13-pull-request.yaml
@@ -257,7 +257,7 @@ spec:
       - name: LABELS
         value:
         - com.redhat.component="quay-builder-qemu-rhcos-container"
-        - name="quay/quay-builder-qemu-rhcos-rhel8"
+        - name=quay/quay-builder-qemu-rhcos-rhel8
         - version=3.13.11
         - io.k8s.display-name="Red Hat Quay - Builder QEMU RHCOS"
         - io.k8s.description="Red Hat Quay - Builder QEMU RHCOS"

--- a/.tekton/quay-builder-qemu-v3-13-push.yaml
+++ b/.tekton/quay-builder-qemu-v3-13-push.yaml
@@ -254,7 +254,7 @@ spec:
       - name: LABELS
         value:
         - com.redhat.component="quay-builder-qemu-rhcos-container"
-        - name="quay/quay-builder-qemu-rhcos-rhel8"
+        - name=quay/quay-builder-qemu-rhcos-rhel8
         - version=3.13.11
         - io.k8s.display-name="Red Hat Quay - Builder QEMU RHCOS"
         - io.k8s.description="Red Hat Quay - Builder QEMU RHCOS"


### PR DESCRIPTION
In Konflux,  [pipeline job](https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rhtap-releng-tenant/applications/quay-v3-13/pipelineruns/managed-ljhq7?releaseName=quay-3-13-stage2k2x8) failed for the following error, update the label value of "name"
```
  ++ jq -c --argjson i 4 '.components[$i]' /var/workdir/release/a9747a91-7ada-4856-ba27-e51d2ba89831/snapshot_spec.json
  + component='{"containerImage":"quay.io/redhat-user-workloads/quay-eng-tenant/quay-builder-qemu-v3-13@sha256:89d8dbc7455fef10d4b6669ea09dc3a767334a9a426f4654c7efc06f4309aaf8","name":"quay-builder-qemu-v3-13","source":{"git":{"revision":"1016f827dd5f1ff9d9997d6ef56e40054b4a28b8","url":"https://github.com/quay/quay-builder-qemu.git"}},"repositories":[{"url":"quay.io/redhat-pending/quay----quay-builder-qemu-rhcos-rhel8","tags":["v3.13","v3.13.11","v3.13.11-1770128431","89d8dbc7455fef10d4b6669ea09dc3a767334a9a426f4654c7efc06f4309aaf8","1770128431"],"rh-registry-repo":"registry.stage.redhat.io/quay/quay-builder-qemu-rhcos-rhel8","registry-access-repo":"registry.access.stage.redhat.com/quay/quay-builder-qemu-rhcos-rhel8"}],"metadata":{"env_variables":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","container=oci"],"labels":[{"name":"architecture","value":"x86_64"},{"name":"build-date","value":"2026-01-27T14:37:09Z"},{"name":"com.redhat.component","value":"\"quay-builder-qemu-rhcos-container\""},{"name":"com.redhat.license_terms","value":"https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"},{"name":"cpe","value":"\"cpe:/a:redhat:quay:3.13::el8\""},{"name":"description","value":"\"Red Hat Quay - Builder QEMU RHCOS\""},{"name":"distribution-scope","value":"\"restricted\""},{"name":"io.buildah.version","value":"1.41.5"},{"name":"io.k8s.description","value":"\"Red Hat Quay - Builder QEMU RHCOS\""},{"name":"io.k8s.display-name","value":"\"Red Hat Quay - Builder QEMU RHCOS\""},{"name":"io.openshift.expose-services","value":""},{"name":"io.openshift.tags","value":"\"quay\""},{"name":"maintainer","value":"\"support@redhat.com\""},{"name":"name","value":"\"quay/quay-builder-qemu-rhcos-rhel8\""},{"name":"org.opencontainers.image.created","value":"2026-01-27T14:37:09Z"},{"name":"org.opencontainers.image.revision","value":"1016f827dd5f1ff9d9997d6ef56e40054b4a28b8"},{"name":"release","value":"3.13"},{"name":"summary","value":"\"Red Hat Quay - Builder QEMU RHCOS\""},{"name":"tags","value":"\"quay\""},{"name":"url","value":"\"https://docs.redhat.com/en/documentation/red_hat_quay/3.13\""},{"name":"vcs-ref","value":"1016f827dd5f1ff9d9997d6ef56e40054b4a28b8"},{"name":"vcs-type","value":"git"},{"name":"vendor","value":"Red Hat, Inc."},{"name":"version","value":"3.13.11"}]}}'
  ++ jq -r .name
  + name=quay-builder-qemu-v3-13
  ++ jq -r '.metadata.labels? | .[] | select(.name == "name") | .value'
  + name_label='"quay/quay-builder-qemu-rhcos-rhel8"'
  + [[ -z "quay/quay-builder-qemu-rhcos-rhel8" ]]
  + [[ "quay/quay-builder-qemu-rhcos-rhel8" == \n\u\l\l ]]
  ++ jq -r '.canonicalName // empty'
  + canonical_name=
  ++ jq '.repositories | length'
  + num_repos=1
  + [[ 1 -eq 1 ]]
  ++ jq -r '.repositories[0]."rh-registry-repo" // empty'
  + url=registry.stage.redhat.io/quay/quay-builder-qemu-rhcos-rhel8
  + [[ -z registry.stage.redhat.io/quay/quay-builder-qemu-rhcos-rhel8 ]]
  ++ derive_name_from_url registry.stage.redhat.io/quay/quay-builder-qemu-rhcos-rhel8
  ++ local url=registry.stage.redhat.io/quay/quay-builder-qemu-rhcos-rhel8
  ++ sed -E 's~^[^/]+://~~; s~^[^/]+/~~; s~[:@].*$~~'
  ++ sed 's#^/*##'
  + derived_name=quay/quay-builder-qemu-rhcos-rhel8
  + [[ "quay/quay-builder-qemu-rhcos-rhel8" != \q\u\a\y\/\q\u\a\y\-\b\u\i\l\d\e\r\-\q\e\m\u\-\r\h\c\o\s\-\r\h\e\l\8 ]]
  + fail_or_warn 'Component '\''quay-builder-qemu-v3-13'\'' name label ('\''"quay/quay-builder-qemu-rhcos-rhel8"'\'') does not match' 'derived name from URL ('\''quay/quay-builder-qemu-rhcos-rhel8'\'')'
  + local 'msg=Component '\''quay-builder-qemu-v3-13'\'' name label ('\''"quay/quay-builder-qemu-rhcos-rhel8"'\'') does not match derived name from URL ('\''quay/quay-builder-qemu-rhcos-rhel8'\'')'
  + '[' true == true ']'
  + echo 'Error: Component '\''quay-builder-qemu-v3-13'\'' name label ('\''"quay/quay-builder-qemu-rhcos-rhel8"'\'') does not match derived name from URL ('\''quay/quay-builder-qemu-rhcos-rhel8'\'')'
  Error: Component 'quay-builder-qemu-v3-13' name label ('"quay/quay-builder-qemu-rhcos-rhel8"') does not match derived name from URL ('quay/quay-builder-qemu-rhcos-rhel8')
  + exit 1
  

STEP-ENFORCE-CPE-LABEL
  2026/02/03 14:22:23 Skipping step because a previous step failed
```