### PR TITLE
Update cpe label value for quay 3.13.11

### DIFF
--- a/.tekton/quay-builder-qemu-v3-13-pull-request.yaml
+++ b/.tekton/quay-builder-qemu-v3-13-pull-request.yaml
@@ -269,7 +269,7 @@ spec:
         - tags="quay"
         - url="https://docs.redhat.com/en/documentation/red_hat_quay/3.13"
         - vendor=Red Hat, Inc.
-        - cpe="cpe:/a:redhat:quay:3.13::el8"
+        - cpe=cpe:/a:redhat:quay:3.13::el8
         - release=3.13
       - name: BUILDAH_FORMAT
         value: $(params.buildah-format)

--- a/.tekton/quay-builder-qemu-v3-13-push.yaml
+++ b/.tekton/quay-builder-qemu-v3-13-push.yaml
@@ -266,7 +266,7 @@ spec:
         - tags="quay"
         - url="https://docs.redhat.com/en/documentation/red_hat_quay/3.13"
         - vendor=Red Hat, Inc.
-        - cpe="cpe:/a:redhat:quay:3.13::el8"
+        - cpe=cpe:/a:redhat:quay:3.13::el8
         - release=3.13
       - name: BUILDAH_FORMAT
         value: $(params.buildah-format)


### PR DESCRIPTION
To fix the following `cpe` label error of [pipeline job](https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rhtap-releng-tenant/applications/quay-v3-13/pipelineruns/managed-k552l?releaseName=quay-v3-13-20260218-083856-000-cea227d-282w6). 
```
+ name=quay-builder-qemu-v3-13
++ jq -r '.metadata.media_type // null'
+ media_type=application/vnd.docker.container.image.v1+json
+ [[ application/vnd.docker.container.image.v1+json != \a\p\p\l\i\c\a\t\i\o\n\/\v\n\d\.\o\c\i\.\i\m\a\g\e\.\c\o\n\f\i\g\.\v\1\+\j\s\o\n ]]
+ [[ application/vnd.docker.container.image.v1+json != \a\p\p\l\i\c\a\t\i\o\n\/\v\n\d\.\d\o\c\k\e\r\.\c\o\n\t\a\i\n\e\r\.\i\m\a\g\e\.\v\1\+\j\s\o\n ]]
++ jq -r '.metadata.labels // [] | .[] | select(.name == "cpe")
        | .value // empty'
+ cpe_label='"cpe:/a:redhat:quay:3.13::el8"'
+ [[ -z "cpe:/a:redhat:quay:3.13::el8" ]]
+ [[ "cpe:/a:redhat:quay:3.13::el8" != \c\p\e\:\/\a\:\r\e\d\h\a\t\:\q\u\a\y\:\3\.\1\3\:\:\e\l\8 ]]
+ fail_or_warn 'Component '\''quay-builder-qemu-v3-13'\'' '\''cpe'\'' label ('\''"cpe:/a:redhat:quay:3.13::el8"'\'') does not match' 'the single required CPE value from the data file ('\''cpe:/a:redhat:quay:3.13::el8'\'').'
+ local 'msg=Component '\''quay-builder-qemu-v3-13'\'' '\''cpe'\'' label ('\''"cpe:/a:redhat:quay:3.13::el8"'\'') does not match the single required CPE value from the data file ('\''cpe:/a:redhat:quay:3.13::el8'\'').'
+ '[' true == true ']'
+ echo 'Error: Component '\''quay-builder-qemu-v3-13'\'' '\''cpe'\'' label ('\''"cpe:/a:redhat:quay:3.13::el8"'\'') does not match the single required CPE value from the data file ('\''cpe:/a:redhat:quay:3.13::el8'\'').'
Error: Component 'quay-builder-qemu-v3-13' 'cpe' label ('"cpe:/a:redhat:quay:3.13::el8"') does not match the single required CPE value from the data file ('cpe:/a:redhat:quay:3.13::el8').
+ exit 1

```