### PR TITLE
Fix OOMKill in ecosystem-cert-preflight-checks for v3-13

### DIFF
--- a/.tekton/quay-builder-qemu-v3-13-pull-request.yaml
+++ b/.tekton/quay-builder-qemu-v3-13-pull-request.yaml
@@ -662,6 +662,15 @@ spec:
       optional: true
     - name: netrc
       optional: true
+  taskRunSpecs:
+  - pipelineTaskName: ecosystem-cert-preflight-checks
+    stepSpecs:
+    - name: app-check
+      computeResources:
+        limits:
+          memory: 8Gi
+        requests:
+          memory: 4Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-quay-builder-qemu-v3-13
   workspaces:

--- a/.tekton/quay-builder-qemu-v3-13-push.yaml
+++ b/.tekton/quay-builder-qemu-v3-13-push.yaml
@@ -659,6 +659,15 @@ spec:
       optional: true
     - name: netrc
       optional: true
+  taskRunSpecs:
+  - pipelineTaskName: ecosystem-cert-preflight-checks
+    stepSpecs:
+    - name: app-check
+      computeResources:
+        limits:
+          memory: 8Gi
+        requests:
+          memory: 4Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-quay-builder-qemu-v3-13
   workspaces:


### PR DESCRIPTION
## Summary

- The `ecosystem-cert-preflight-checks` post-build task was OOMKilling on 2 of 4 arch variants (exit code 137) during the `step-app-check` container run
- Root cause: no memory limit was set for the `app-check` step in the external bundle task, causing the preflight scan to exhaust available memory on some platforms
- Fix: add `taskRunSpecs.stepSpecs` override with `limits.memory: 8Gi` and `requests.memory: 4Gi` for the `app-check` step in both push and pull-request pipelines

## Test plan

- [ ] Verify the push pipeline runs `ecosystem-cert-preflight-checks` without OOMKill on all 4 platforms (linux/x86_64, linux/arm64, linux/ppc64le, linux/s390x)
- [ ] Confirm the PR pipeline preflight checks also complete successfully
- [ ] Check that the memory request (4Gi) does not cause scheduling issues on the cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)