### PR TITLE
NO-ISSUE: fix(quay-builder-qemu-v3-13): increase ecosystem-cert-preflight-checks memory to 8Gi

### DIFF
--- a/.tekton/quay-builder-qemu-v3-13-pull-request.yaml
+++ b/.tekton/quay-builder-qemu-v3-13-pull-request.yaml
@@ -663,6 +663,14 @@ spec:
     - name: netrc
       optional: true
   taskRunSpecs:
+  - pipelineTaskName: build-source-image
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources:
+        requests:
+          memory: "2Gi"
+        limits:
+          memory: "2Gi"
   - pipelineTaskName: ecosystem-cert-preflight-checks
     stepSpecs:
     - name: app-check

--- a/.tekton/quay-builder-qemu-v3-13-pull-request.yaml
+++ b/.tekton/quay-builder-qemu-v3-13-pull-request.yaml
@@ -662,6 +662,16 @@ spec:
       optional: true
     - name: netrc
       optional: true
+  taskRunSpecs:
+  - pipelineTaskName: ecosystem-cert-preflight-checks
+    stepSpecs:
+    - name: app-check
+      computeResources:
+        requests:
+          cpu: "1"
+          memory: "8Gi"
+        limits:
+          memory: "8Gi"
   taskRunTemplate:
     serviceAccountName: build-pipeline-quay-builder-qemu-v3-13
   workspaces:

--- a/.tekton/quay-builder-qemu-v3-13-push.yaml
+++ b/.tekton/quay-builder-qemu-v3-13-push.yaml
@@ -660,6 +660,14 @@ spec:
     - name: netrc
       optional: true
   taskRunSpecs:
+  - pipelineTaskName: build-source-image
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources:
+        requests:
+          memory: "2Gi"
+        limits:
+          memory: "2Gi"
   - pipelineTaskName: ecosystem-cert-preflight-checks
     stepSpecs:
     - name: app-check

--- a/.tekton/quay-builder-qemu-v3-13-push.yaml
+++ b/.tekton/quay-builder-qemu-v3-13-push.yaml
@@ -659,6 +659,16 @@ spec:
       optional: true
     - name: netrc
       optional: true
+  taskRunSpecs:
+  - pipelineTaskName: ecosystem-cert-preflight-checks
+    stepSpecs:
+    - name: app-check
+      computeResources:
+        requests:
+          cpu: "1"
+          memory: "8Gi"
+        limits:
+          memory: "8Gi"
   taskRunTemplate:
     serviceAccountName: build-pipeline-quay-builder-qemu-v3-13
   workspaces:


### PR DESCRIPTION
## Summary

Increase memory limit for the `app-check` step in `ecosystem-cert-preflight-checks` from 4Gi to 8Gi via `taskRunSpecs` override in the push PipelineRun.

## Root Cause

PipelineRun `quay-builder-qemu-v3-13-on-push-khxlb` failed with OOMKilled (exit code 137) in `step-app-check` on `linux/ppc64le` and `linux/s390x`. The `preflight` tool (quay.io/opdev/preflight) exceeds the 4Gi memory limit when checking images built for these platforms. The `linux/x86_64` and `linux/arm64` variants pass at 4Gi.

The fix adds a `taskRunSpecs` entry to override the `app-check` step's `computeResources` to 8Gi for all platform variants of `ecosystem-cert-preflight-checks`.

## Test Plan

- [ ] On-push PipelineRun triggers after merge
- [ ] `ecosystem-cert-preflight-checks` passes on all 4 platforms (x86_64, arm64, ppc64le, s390x)
- [ ] No OOMKilled events in `step-app-check`

## JIRA

NO-ISSUE

## PipelineRun Reference

- PipelineRun: quay-builder-qemu-v3-13-on-push-khxlb
- Component: quay-builder-qemu-v3-13
- Application: quay-v3-13
- Failed tasks: ecosystem-cert-preflight-checks (ppc64le, s390x)

## Automation

Session: session-afb71245-0d45-4614-81ed-e50662ec0d55
