### PR TITLE
PROJQUAY-11621: docs: add repo context files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# Agent Guide: quay-builder-qemu
+
+## Purpose
+
+Builds a container image that boots Fedora CoreOS under QEMU/KVM for isolated builder workflows.
+
+## Start Here
+
+- Image build: `Dockerfile`
+- VM boot: `start.sh`
+- Build helper: `build.sh`
+- Detailed flow: `ARCHITECTURE.md`
+
+## Common Tasks
+
+- Update CoreOS source: adjust `CHANNEL` or `CLOUD_IMAGE` handling and test a boot.
+- Change VM resources: edit `VM_MEMORY`, `VM_VOLUME_SIZE`, or QEMU flags in `start.sh`.
+- Debug boot: inspect userdata, QEMU flags, and stream metadata.
+
+## Commands
+
+```bash
+TAG=test IMAGE=quay-builder-qemu ./build.sh
+docker run --rm --privileged -e USERDATA="$(cat user_data)" quay-builder-qemu:test
+```
+
+## Guardrails
+
+- Do not commit downloaded qcow2 images or userdata with secrets.
+- This repo does not execute full Quay build jobs; orchestration lives in `quay-builder` and `quay/buildman`.
+- QEMU flag changes affect host permissions and isolation.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,73 @@
+# quay-builder-qemu Architecture
+
+`quay-builder-qemu` packages a Fedora CoreOS QEMU disk image with enough host tooling to boot that image inside a container. It is an executor building block for Quay builder flows that need stronger isolation than a normal container process.
+
+## Build-Time Flow
+
+```mermaid
+flowchart TB
+    dockerfile[Dockerfile]
+    base[CentOS Stream 9 base]
+    stream[Fedora CoreOS stream JSON]
+    qcow[coreos_production_qemu_image.qcow2]
+    tools[qemu-kvm and openssh-clients]
+    final[executor image]
+
+    dockerfile --> base
+    base --> stream
+    stream --> qcow
+    base --> tools
+    qcow --> final
+    tools --> final
+```
+
+The Dockerfile uses a multi-stage build:
+
+- `base`: installs `jq` and `xz`, then reads Fedora CoreOS stream metadata.
+- `executor-img`: downloads and unpacks the QEMU `qcow2.xz` image.
+- `final`: installs runtime tools, copies the disk image and `start.sh`, and sets the entrypoint.
+
+## Runtime Flow
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant Entrypoint as start.sh
+    participant Disk as CoreOS qcow2
+    participant QEMU as qemu-kvm
+    participant Guest as CoreOS guest
+
+    Caller->>Entrypoint: run container with USERDATA, VM_MEMORY, VM_VOLUME_SIZE
+    Entrypoint->>Disk: write USERDATA and check virtual disk size
+    Entrypoint->>Disk: resize copy when VM_VOLUME_SIZE is larger
+    Entrypoint->>QEMU: boot with KVM, virtio disk, user networking, SSH forward
+    QEMU->>Guest: pass userdata through fw_cfg
+    Guest-->>Caller: executes configured workload
+```
+
+`start.sh` boots with:
+
+- KVM acceleration and host CPU passthrough.
+- Virtio disk backed by `/userdata/coreos_production_qemu_image.qcow2`.
+- `fw_cfg` userdata injection at `opt/com.coreos/config`.
+- User-mode networking with host port `2222` forwarded to guest SSH port `22`.
+- Two virtual CPUs and configurable memory.
+
+## Inputs
+
+- `USERDATA`: required guest configuration. The script writes this to `/userdata/user_data`.
+- `VM_VOLUME_SIZE`: optional disk size, default `32G`.
+- `VM_MEMORY`: optional memory size, default `4G`.
+- `CHANNEL`: Fedora CoreOS stream used at build time, default `stable`.
+- `CLOUD_IMAGE`: optional explicit CoreOS image location for `build.sh`.
+- `IMAGE` and `TAG`: target image name for `build.sh`.
+
+## Security Boundary
+
+The VM boundary is the point of this repo. Builds or workloads that run in the guest should not rely on the container filesystem for isolation. The container still needs elevated runtime permissions for KVM, so cluster-level policy and node placement remain important.
+
+## Operational Notes
+
+- The repository does not contain Quay build manager code; see `quay-builder` and `quay/buildman` for job orchestration.
+- Keep Fedora CoreOS channel updates deliberate. A channel bump changes the guest operating system for every downstream executor image.
+- Validate changes by building the image and booting it with minimal userdata before wiring it into a Quay builder workflow.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing to quay-builder-qemu
+
+Keep changes focused on the executor image, boot script, and CoreOS image selection. Changes to Quay build job orchestration belong in `quay-builder` or `quay/buildman`.
+
+## Setup
+
+You need a container runtime and host support for KVM to fully test this repository:
+
+```bash
+docker build --build-arg channel=stable -t quay-builder-qemu:test .
+```
+
+For a full boot test, run the image on a host where `/dev/kvm` is available and privileged containers are allowed.
+
+## Testing
+
+```bash
+TAG=test IMAGE=quay-builder-qemu ./build.sh
+
+docker run --rm --privileged \
+  -e USERDATA="$(cat user_data)" \
+  -e VM_MEMORY=2G \
+  -e VM_VOLUME_SIZE=16G \
+  quay-builder-qemu:test
+```
+
+Use minimal userdata for smoke tests, then test the real builder userdata in the downstream environment that consumes this image.
+
+## Pull Requests
+
+- State the Fedora CoreOS channel or image URL used for validation.
+- Include whether the change affects build time, boot time, networking, disk size, or memory.
+- Do not include local qcow2 files, credentials, or generated userdata.
+- Ask for review from builder owners when QEMU flags or guest boot behavior changes.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,29 @@
 ```
 docker build --build-arg channel=stable -t quay.io/quay/quay-builder-qemu-coreos:staging .
 ```
+
+## Contextification Addendum
+
+```mermaid
+flowchart LR
+    build[Dockerfile build]
+    stream[CoreOS stream metadata]
+    qcow[qcow2 image]
+    image[executor image]
+    userdata[USERDATA]
+    qemu[QEMU/KVM guest]
+
+    stream --> build
+    build --> qcow
+    qcow --> image
+    userdata --> image
+    image --> qemu
+```
+
+Key files: `Dockerfile`, `start.sh`, and `build.sh`. Validate image build with:
+
+```bash
+TAG=test IMAGE=quay-builder-qemu ./build.sh
+```
+
+Full validation needs a host that can run privileged containers with KVM.


### PR DESCRIPTION
## Summary
Adds required contextification docs for `quay-builder-qemu` as part of PROJQUAY-11621.

## Changes
  - Adds `AGENTS.md` with low-token routing for AI agents.
  - Adds `ARCHITECTURE.md` describing the CoreOS/QEMU executor image, build-time flow, runtime flow, inputs, and
  security boundary.
  - Adds `CONTRIBUTING.md` with setup, testing, and review guidance.
  - Updates `README.md` with a contextification addendum, architecture diagram, key files, and validation command.